### PR TITLE
Harden v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,8 @@ Top-level options exposed by the [Default Engine](#plugins-and-engines):
 | options | description | default |
 |---------|-------------|---------|
 | errorFormatter | function to format `Error` into JSON | `error => _.pick(error, ['message', 'code', 'details']` |
-| commandExchangeName | The exchange name to use for `send` | `'commands'` |
-| eventExchangeName | The exchange name to use for publish | `'events'` |
-| subscriptionQueueName | The queue `subscribe` workers get pushed from | `'${serviceName}_subscription'` |
-| listenQueueName | The queue the `listen` workers get pushed from | `'${serviceName}_listen'` |
+| topicExchangeName | The exchange name to use for `send` | `'amqp.topic'` |
+| fanoutExchangeName | The exchange name to use for publish | `'amqp.fanout'` |
 
 You can provide custom options when initializing BunnyHop.
 

--- a/src/example/listen.js
+++ b/src/example/listen.js
@@ -2,8 +2,8 @@
  * Created by balmasi on 2017-05-30.
  */
 
-const BunnyHop = require('./../index');
-const { Package, Logging } = require('././plugins');
+const BunnyHop = require('../index');
+const { Package, Logging } = BunnyHop.Plugins;
 
 const bus = BunnyHop('consumer_one')
   .use(Package)
@@ -12,7 +12,7 @@ const bus = BunnyHop('consumer_one')
 function doSomething (msg) {
   return new Promise((resolve, reject) => {
     setTimeout(function () {
-      console.log(`${msg.properties.correlationId}: Doing some hard work for 2 seconds...`);
+      console.log(`Doing some hard work for 2 seconds...`);
       // After some heavy deliberation
       resolve({
         answer: `The time the message was created was ${new Date(msg.content.data.when).toISOString()}`
@@ -23,4 +23,4 @@ function doSomething (msg) {
   });
 }
 
-bus.listen('cmd.test.doSomething', doSomething);
+bus.listen('cmd.test.*', doSomething);

--- a/src/example/publish.js
+++ b/src/example/publish.js
@@ -2,7 +2,7 @@
  * Created by balmasi on 2017-06-03.
  */
 
-const BunnyHop = require('./../index');
+const BunnyHop = require('../index');
 const { Logging, Correlator } = BunnyHop.Plugins;
 
 const bus = BunnyHop('TestService')
@@ -20,3 +20,6 @@ setInterval(
   1000
 );
 
+ON_DEATH(() => {
+  process.nextTick(() => process.exit(0))
+});

--- a/src/example/publish.js
+++ b/src/example/publish.js
@@ -2,6 +2,8 @@
  * Created by balmasi on 2017-06-03.
  */
 
+const ON_DEATH = require('death');
+
 const BunnyHop = require('../index');
 const { Logging, Correlator } = BunnyHop.Plugins;
 

--- a/src/example/send.js
+++ b/src/example/send.js
@@ -24,7 +24,7 @@ setInterval(
       .then(r => console.log('RESULT ', r))
       .catch(e => console.error('ERROR', e))
   },
-  8000
+  4000
 );
 
 ON_DEATH(() => {

--- a/src/example/send.js
+++ b/src/example/send.js
@@ -8,14 +8,18 @@ const { Package, Logging } = BunnyHop.Plugins;
 
 const bus = BunnyHop('TestService')
   .use(Logging)
-  .use(Package);
+  // .use(Package);
 
 setInterval(
   () => {
     bus.send(
       'cmd.test.doSomething',
       { when: Date.now() },
-      // { sync: true } // RPC
+      {
+        // sync: true, // adds 'x-isRPC': true to header. (resolves returned promise with answer or rejects with error)
+        // correlationId: 'customCorId', // Provide custom correlationId
+        // type: 'arbitraryType' // custom msg.properties.type
+      }
     )
       .then(r => console.log('RESULT ', r))
       .catch(e => console.error('ERROR', e))

--- a/src/example/send.js
+++ b/src/example/send.js
@@ -2,23 +2,27 @@
  * Created by balmasi on 2017-06-02.
  */
 
-const BunnyHop = require('./../index');
-const { Package, Logging } = require('././plugins');
+const ON_DEATH = require('death');
+const BunnyHop = require('../index');
+const { Package, Logging } = BunnyHop.Plugins;
 
 const bus = BunnyHop('TestService')
   .use(Logging)
   .use(Package);
 
-
-
 setInterval(
   () => {
     bus.send(
       'cmd.test.doSomething',
-      { when: Date.now() }
+      { when: Date.now() },
+      // { sync: true } // RPC
     )
       .then(r => console.log('RESULT ', r))
       .catch(e => console.error('ERROR', e))
   },
-  1000
+  8000
 );
+
+ON_DEATH(() => {
+  process.nextTick(() => process.exit(0))
+});

--- a/src/example/subscribe.js
+++ b/src/example/subscribe.js
@@ -2,7 +2,7 @@
  * Created by balmasi on 2017-05-30.
  */
 
-const BunnyHop = require('./../index');
+const BunnyHop = require('../index');
 const { Logging, Correlator } = BunnyHop.Plugins;
 
 const bus = BunnyHop('consumer_two')

--- a/src/lib/connectionManager.js
+++ b/src/lib/connectionManager.js
@@ -6,8 +6,18 @@ const debug = require('debug');
 const ON_DEATH = require('death');
 
 const log = {
-  info: debug('bunnyhop:info')
+  info: debug('bunnyhop:info'),
+  warn: debug('bunnyhop:warn')
 };
+
+async function close (closable) {
+  try {
+    await closable.close();
+  } catch (err) {
+    log.warn(`Having trouble closing connection: ${err.message}`);
+    /* catch errors */
+  }
+}
 
 /**
  * Connection function to AMQP host
@@ -40,11 +50,11 @@ module.exports = async function connect (amqpUrl) {
   ON_DEATH(function (signal, error) {
     const message = `Stopping all AMQP connections due to ${signal ? `${signal} signal` : 'error'}.`;
     log.info(message);
-    if (connection) {
-      connection.close();
-    }
     if (channel) {
-      channel.close();
+      close(channel);
+    }
+    if (connection) {
+      close(connection);
     }
   });
 

--- a/src/lib/engines/default.engine.js
+++ b/src/lib/engines/default.engine.js
@@ -55,7 +55,7 @@ function DefaultEngine (pluginAPI) {
         if (options.sync) {
           const { queue } = await ch.assertQueue('', { exclusive: true });
           return new Promise(async (resolve, reject) => {
-            const uid = uuid.v4();
+            const uid = options.correlationId || uuid.v4();
 
             function maybeAnswer (msg) {
               if (msg.properties.correlationId === uid) {

--- a/src/lib/engines/default.engine.js
+++ b/src/lib/engines/default.engine.js
@@ -43,6 +43,7 @@ function DefaultEngine (pluginAPI) {
         await ch.assertExchange(exchange, EXCHANGE_TYPE.DIRECT);
         // Generate custom publish options here (like custom headers)
         const commonOptions = _.merge(
+          { appId: serviceName },
           options,
           {
             headers: {
@@ -138,7 +139,11 @@ function DefaultEngine (pluginAPI) {
         const exchange = engineOptions.eventExchangeName;
         await ch.assertExchange(exchange, EXCHANGE_TYPE.TOPIC);
         const msgBuffer = serialize(message);
-        const modifiedOptions = Object.assign({}, options, { persistent: true });
+        const modifiedOptions = Object.assign(
+          { appId: serviceName },
+          options,
+          { persistent: true }
+        );
         return ch.publish(exchange, routingKey, msgBuffer, modifiedOptions);
       },
 

--- a/src/lib/plugins/package.plugin.js
+++ b/src/lib/plugins/package.plugin.js
@@ -45,7 +45,7 @@ function packageIncomingMessage (message, routingKey) {
       content: {
         dateProcessed: (new Date()).toISOString(),
         data: _.omit(data, ['type']),
-        type: routingKey,
+        type: _.get(message, 'fields.routingKey'),
         dateIssued
       }
     },


### PR DESCRIPTION
fix: fixed example imports			7578760
fix: close channel before closing connection			cfd3d14
feat: add sync flag to get RPC			18b298b
feat: allow custom correlationIds provided via options  …			99a9d16
fix: get message type from send routing key (rather than listen)			3da398c
feat: add appId to messages			056882c
fix: fixed send/listen bug so listeners now gets own queue per topic			a1739b9
fix: correct publish/subscribe behaviour			6465b68
