### PR TITLE
Making subscribe work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules
 build
 
 npm-debug.log
+
+.idea

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autolotto/bunnyhop",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "main": "build/index.js",
   "license": "MIT",
   "repository": "https://github.com/autolotto/bunnyhop",


### PR DESCRIPTION
This is a quick patch to try to make subscribe work the way I think we thought it would work. 

For AMQP pubsub each "queue" is a destination;  essentially when you bind a queue to a routing key you are saying "Hey exchange! Put stuff with this routing key into this queue!"

We are currently using a single hardcoded queue "subscription queue" which doesn't really work with this concept, if I subscribe Function A on topic A and Function B on topic B I don't want them on the same queue.  I.e. I don't want  messages on Topic B to be sent to Function A.   

What I think we want is for each subscription we want to create a new "destination" that we connect to the exchange with a specific routing key/pattern. 

This means generating a new queue for each subscribe.  

See the patch. 