### PR TITLE
DateMiddleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "babel-plugin-transform-async-to-generator": "6.24.1",
         "babel-plugin-transform-es2015-destructuring": "6.23.0",
         "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
         "babel-plugin-transform-es2015-parameters": "6.24.1",
         "babel-plugin-transform-es2015-spread": "6.22.0",
         "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
@@ -71,14 +71,15 @@
       }
     },
     "amqplib": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.5.1.tgz",
-      "integrity": "sha1-fMz+ur5WwumE6noiQ/fO/m+/xs8=",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.5.2.tgz",
+      "integrity": "sha512-l9mCs6LbydtHqRniRwYkKdqxVa6XMz3Vw1fh+2gJaaVgTM6Jk3o8RccAKWKtlhT1US5sWrFh+KKxsVUALURSIA==",
       "requires": {
         "bitsyntax": "0.0.4",
-        "bluebird": "3.5.0",
+        "bluebird": "3.5.1",
         "buffer-more-ints": "0.0.2",
-        "readable-stream": "1.1.14"
+        "readable-stream": "1.1.14",
+        "safe-buffer": "5.1.1"
       }
     },
     "ansi-align": {
@@ -91,9 +92,9 @@
       }
     },
     "ansi-escapes": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
-      "integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
       "dev": true
     },
     "ansi-regex": {
@@ -220,25 +221,25 @@
         "arrify": "1.0.1",
         "auto-bind": "1.1.0",
         "ava-init": "0.2.1",
-        "babel-code-frame": "6.22.0",
-        "babel-core": "6.25.0",
-        "bluebird": "3.5.0",
+        "babel-code-frame": "6.26.0",
+        "babel-core": "6.26.0",
+        "bluebird": "3.5.1",
         "caching-transform": "1.0.1",
         "chalk": "1.1.3",
         "chokidar": "1.7.0",
         "clean-stack": "1.3.0",
         "clean-yaml-object": "0.1.0",
         "cli-cursor": "2.1.0",
-        "cli-spinners": "1.0.0",
+        "cli-spinners": "1.1.0",
         "cli-truncate": "1.1.0",
         "co-with-promise": "4.6.0",
         "code-excerpt": "2.1.0",
         "common-path-prefix": "1.0.0",
-        "convert-source-map": "1.5.0",
+        "convert-source-map": "1.5.1",
         "core-assert": "0.2.1",
         "currently-unhandled": "0.4.1",
-        "debug": "2.6.8",
-        "diff": "3.3.0",
+        "debug": "2.6.9",
+        "diff": "3.4.0",
         "diff-match-patch": "1.0.0",
         "dot-prop": "4.2.0",
         "empower-core": "0.6.2",
@@ -246,7 +247,7 @@
         "figures": "2.0.0",
         "find-cache-dir": "0.1.1",
         "fn-name": "2.0.1",
-        "get-port": "3.1.0",
+        "get-port": "3.2.0",
         "globby": "6.1.0",
         "has-flag": "2.0.0",
         "hullabaloo-config-manager": "1.1.1",
@@ -259,7 +260,7 @@
         "is-promise": "2.1.0",
         "jest-diff": "19.0.0",
         "jest-snapshot": "19.0.2",
-        "js-yaml": "3.9.1",
+        "js-yaml": "3.10.0",
         "last-line-stream": "1.0.0",
         "lodash.debounce": "4.0.8",
         "lodash.difference": "4.5.0",
@@ -281,14 +282,14 @@
         "require-precompiled": "0.1.0",
         "resolve-cwd": "1.0.0",
         "slash": "1.0.0",
-        "source-map-support": "0.4.15",
+        "source-map-support": "0.4.18",
         "stack-utils": "1.0.1",
         "strip-ansi": "3.0.1",
         "strip-bom-buf": "1.0.0",
         "supports-color": "3.2.3",
         "time-require": "0.1.2",
         "unique-temp-dir": "1.0.0",
-        "update-notifier": "2.2.0"
+        "update-notifier": "2.3.0"
       },
       "dependencies": {
         "ms": {
@@ -323,142 +324,22 @@
         "babel-register": "6.26.0",
         "babel-runtime": "6.26.0",
         "chokidar": "1.7.0",
-        "commander": "2.11.0",
-        "convert-source-map": "1.5.0",
-        "fs-readdir-recursive": "1.0.0",
+        "commander": "2.12.2",
+        "convert-source-map": "1.5.1",
+        "fs-readdir-recursive": "1.1.0",
         "glob": "7.1.2",
         "lodash": "4.17.4",
         "output-file-sync": "1.1.2",
         "path-is-absolute": "1.0.1",
         "slash": "1.0.0",
-        "source-map": "0.5.6",
+        "source-map": "0.5.7",
         "v8flags": "2.1.1"
-      },
-      "dependencies": {
-        "babel-code-frame": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          }
-        },
-        "babel-core": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-          "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
-          "dev": true,
-          "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-generator": "6.26.0",
-            "babel-helpers": "6.24.1",
-            "babel-messages": "6.23.0",
-            "babel-register": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "convert-source-map": "1.5.0",
-            "debug": "2.6.8",
-            "json5": "0.5.1",
-            "lodash": "4.17.4",
-            "minimatch": "3.0.4",
-            "path-is-absolute": "1.0.1",
-            "private": "0.1.7",
-            "slash": "1.0.0",
-            "source-map": "0.5.6"
-          }
-        },
-        "babel-generator": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
-          "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
-          "dev": true,
-          "requires": {
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "detect-indent": "4.0.0",
-            "jsesc": "1.3.0",
-            "lodash": "4.17.4",
-            "source-map": "0.5.6",
-            "trim-right": "1.0.1"
-          }
-        },
-        "babel-runtime": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-          "dev": true,
-          "requires": {
-            "core-js": "2.5.0",
-            "regenerator-runtime": "0.11.0"
-          }
-        },
-        "babel-template": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.4"
-          }
-        },
-        "babel-traverse": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-          "dev": true,
-          "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.8",
-            "globals": "9.18.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
-          }
-        },
-        "babel-types": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "1.0.3"
-          }
-        },
-        "jsesc": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-          "dev": true
-        },
-        "regenerator-runtime": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
-          "dev": true
-        }
       }
     },
     "babel-code-frame": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
@@ -467,45 +348,45 @@
       }
     },
     "babel-core": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
-      "integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+      "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.22.0",
-        "babel-generator": "6.25.0",
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.0",
         "babel-helpers": "6.24.1",
         "babel-messages": "6.23.0",
         "babel-register": "6.26.0",
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
         "babylon": "6.18.0",
-        "convert-source-map": "1.5.0",
-        "debug": "2.6.8",
+        "convert-source-map": "1.5.1",
+        "debug": "2.6.9",
         "json5": "0.5.1",
         "lodash": "4.17.4",
         "minimatch": "3.0.4",
         "path-is-absolute": "1.0.1",
-        "private": "0.1.7",
+        "private": "0.1.8",
         "slash": "1.0.0",
-        "source-map": "0.5.6"
+        "source-map": "0.5.7"
       }
     },
     "babel-generator": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
-      "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
+      "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
       "dev": true,
       "requires": {
         "babel-messages": "6.23.0",
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
         "detect-indent": "4.0.0",
         "jsesc": "1.3.0",
         "lodash": "4.17.4",
-        "source-map": "0.5.6",
+        "source-map": "0.5.7",
         "trim-right": "1.0.1"
       },
       "dependencies": {
@@ -524,8 +405,8 @@
       "dev": true,
       "requires": {
         "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-call-delegate": {
@@ -535,20 +416,20 @@
       "dev": true,
       "requires": {
         "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-define-map": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
-      "integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+      "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
       "dev": true,
       "requires": {
         "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
         "lodash": "4.17.4"
       }
     },
@@ -558,9 +439,9 @@
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-function-name": {
@@ -570,10 +451,10 @@
       "dev": true,
       "requires": {
         "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-get-function-arity": {
@@ -582,8 +463,8 @@
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-hoist-variables": {
@@ -592,8 +473,8 @@
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-optimise-call-expression": {
@@ -602,18 +483,18 @@
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
-      "integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
         "lodash": "4.17.4"
       }
     },
@@ -624,10 +505,10 @@
       "dev": true,
       "requires": {
         "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-replace-supers": {
@@ -638,10 +519,10 @@
       "requires": {
         "babel-helper-optimise-call-expression": "6.24.1",
         "babel-messages": "6.23.0",
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helpers": {
@@ -650,8 +531,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-messages": {
@@ -660,7 +541,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.25.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -669,7 +550,7 @@
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.25.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-espower": {
@@ -678,10 +559,10 @@
       "integrity": "sha1-VRa4/NsmyfDh2BYHSfbkxl5xJx4=",
       "dev": true,
       "requires": {
-        "babel-generator": "6.25.0",
+        "babel-generator": "6.26.0",
         "babylon": "6.18.0",
         "call-matcher": "1.0.1",
-        "core-js": "2.5.0",
+        "core-js": "2.5.1",
         "espower-location-detector": "1.0.0",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
@@ -713,7 +594,7 @@
       "requires": {
         "babel-helper-remap-async-to-generator": "6.24.1",
         "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.25.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-arrow-functions": {
@@ -722,7 +603,7 @@
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.25.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -731,19 +612,19 @@
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.25.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-block-scoping": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
-      "integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
         "lodash": "4.17.4"
       }
     },
@@ -753,15 +634,15 @@
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
       "dev": true,
       "requires": {
-        "babel-helper-define-map": "6.24.1",
+        "babel-helper-define-map": "6.26.0",
         "babel-helper-function-name": "6.24.1",
         "babel-helper-optimise-call-expression": "6.24.1",
         "babel-helper-replace-supers": "6.24.1",
         "babel-messages": "6.23.0",
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-computed-properties": {
@@ -770,8 +651,8 @@
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -780,7 +661,7 @@
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.25.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
@@ -789,8 +670,8 @@
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-for-of": {
@@ -799,7 +680,7 @@
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.25.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -809,8 +690,8 @@
       "dev": true,
       "requires": {
         "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-literals": {
@@ -819,7 +700,7 @@
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.25.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-amd": {
@@ -828,21 +709,21 @@
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0"
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
-      "integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
+      "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
       "dev": true,
       "requires": {
         "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
@@ -852,8 +733,8 @@
       "dev": true,
       "requires": {
         "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-umd": {
@@ -863,8 +744,8 @@
       "dev": true,
       "requires": {
         "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-object-super": {
@@ -874,7 +755,7 @@
       "dev": true,
       "requires": {
         "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.25.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -885,10 +766,10 @@
       "requires": {
         "babel-helper-call-delegate": "6.24.1",
         "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
@@ -897,8 +778,8 @@
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -907,7 +788,7 @@
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.25.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -916,9 +797,9 @@
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.24.1",
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-template-literals": {
@@ -927,7 +808,7 @@
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.25.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
@@ -936,7 +817,7 @@
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.25.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -945,8 +826,8 @@
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "6.24.1",
-        "babel-runtime": "6.25.0",
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
         "regexpu-core": "2.0.0"
       }
     },
@@ -958,16 +839,16 @@
       "requires": {
         "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
         "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.25.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-regenerator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
-      "integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+      "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
       "dev": true,
       "requires": {
-        "regenerator-transform": "0.9.11"
+        "regenerator-transform": "0.10.1"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -976,8 +857,8 @@
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-polyfill": {
@@ -987,34 +868,22 @@
       "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.0",
+        "core-js": "2.5.1",
         "regenerator-runtime": "0.10.5"
       },
       "dependencies": {
-        "babel-runtime": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-          "dev": true,
-          "requires": {
-            "core-js": "2.5.0",
-            "regenerator-runtime": "0.11.0"
-          },
-          "dependencies": {
-            "regenerator-runtime": {
-              "version": "0.11.0",
-              "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-              "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
-              "dev": true
-            }
-          }
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "dev": true
         }
       }
     },
     "babel-preset-env": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.0.tgz",
-      "integrity": "sha512-OVgtQRuOZKckrILgMA5rvctvFZPv72Gua9Rt006AiPoB0DJKGN07UmaQA+qRrYgK71MVct8fFhT0EyNWYorVew==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
+      "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
       "dev": true,
       "requires": {
         "babel-plugin-check-es2015-constants": "6.22.0",
@@ -1022,7 +891,7 @@
         "babel-plugin-transform-async-to-generator": "6.24.1",
         "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
         "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.24.1",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
         "babel-plugin-transform-es2015-classes": "6.24.1",
         "babel-plugin-transform-es2015-computed-properties": "6.24.1",
         "babel-plugin-transform-es2015-destructuring": "6.23.0",
@@ -1031,7 +900,7 @@
         "babel-plugin-transform-es2015-function-name": "6.24.1",
         "babel-plugin-transform-es2015-literals": "6.22.0",
         "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
         "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
         "babel-plugin-transform-es2015-modules-umd": "6.24.1",
         "babel-plugin-transform-es2015-object-super": "6.24.1",
@@ -1043,8 +912,8 @@
         "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.24.1",
-        "browserslist": "2.3.3",
+        "babel-plugin-transform-regenerator": "6.26.0",
+        "browserslist": "2.9.1",
         "invariant": "2.2.2",
         "semver": "5.4.1"
       }
@@ -1057,180 +926,60 @@
       "requires": {
         "babel-core": "6.26.0",
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.0",
+        "core-js": "2.5.1",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.4",
         "mkdirp": "0.5.1",
-        "source-map-support": "0.4.15"
-      },
-      "dependencies": {
-        "babel-code-frame": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
-          }
-        },
-        "babel-core": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-          "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
-          "dev": true,
-          "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-generator": "6.26.0",
-            "babel-helpers": "6.24.1",
-            "babel-messages": "6.23.0",
-            "babel-register": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "convert-source-map": "1.5.0",
-            "debug": "2.6.8",
-            "json5": "0.5.1",
-            "lodash": "4.17.4",
-            "minimatch": "3.0.4",
-            "path-is-absolute": "1.0.1",
-            "private": "0.1.7",
-            "slash": "1.0.0",
-            "source-map": "0.5.6"
-          }
-        },
-        "babel-generator": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
-          "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
-          "dev": true,
-          "requires": {
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "detect-indent": "4.0.0",
-            "jsesc": "1.3.0",
-            "lodash": "4.17.4",
-            "source-map": "0.5.6",
-            "trim-right": "1.0.1"
-          }
-        },
-        "babel-runtime": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-          "dev": true,
-          "requires": {
-            "core-js": "2.5.0",
-            "regenerator-runtime": "0.11.0"
-          }
-        },
-        "babel-template": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.4"
-          }
-        },
-        "babel-traverse": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-          "dev": true,
-          "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.8",
-            "globals": "9.18.0",
-            "invariant": "2.2.2",
-            "lodash": "4.17.4"
-          }
-        },
-        "babel-types": {
-          "version": "6.26.0",
-          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.4",
-            "to-fast-properties": "1.0.3"
-          }
-        },
-        "jsesc": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-          "dev": true
-        },
-        "regenerator-runtime": {
-          "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-          "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
-          "dev": true
-        }
+        "source-map-support": "0.4.18"
       }
     },
     "babel-runtime": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
-      "integrity": "sha1-M7mOql1IK7AajRqmtDetKwGuxBw=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.0",
-        "regenerator-runtime": "0.10.5"
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.11.0"
       }
     },
     "babel-template": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-      "integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
         "babylon": "6.18.0",
         "lodash": "4.17.4"
       }
     },
     "babel-traverse": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-      "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.22.0",
+        "babel-code-frame": "6.26.0",
         "babel-messages": "6.23.0",
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
         "babylon": "6.18.0",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "globals": "9.18.0",
         "invariant": "2.2.2",
         "lodash": "4.17.4"
       }
     },
     "babel-types": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-      "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.25.0",
+        "babel-runtime": "6.26.0",
         "esutils": "2.0.2",
         "lodash": "4.17.4",
         "to-fast-properties": "1.0.3"
@@ -1249,9 +998,9 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
-      "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true
     },
     "bitsyntax": {
@@ -1263,19 +1012,19 @@
       }
     },
     "bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "boxen": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.2.1.tgz",
-      "integrity": "sha1-DxHn/jRO25OXl3/BPt5/ZNlWSB0=",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.2.2.tgz",
+      "integrity": "sha1-Px1AMsMP/qnUsCwyLq8up0HcvOU=",
       "dev": true,
       "requires": {
         "ansi-align": "2.0.0",
         "camelcase": "4.1.0",
-        "chalk": "2.1.0",
+        "chalk": "2.3.0",
         "cli-boxes": "1.0.0",
         "string-width": "2.1.1",
         "term-size": "1.2.0",
@@ -1288,7 +1037,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "camelcase": {
@@ -1298,20 +1047,20 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.2.1"
+            "supports-color": "4.5.0"
           }
         },
         "supports-color": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -1341,13 +1090,13 @@
       }
     },
     "browserslist": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.3.3.tgz",
-      "integrity": "sha512-p9hz6FA2H1w1ZUAXKfK3MlIA4Z9fEd56hnZSOecBIITb5j0oZk/tZRwhdE0xG56RGx2x8cc1c5AWJKWVjMLOEQ==",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.9.1.tgz",
+      "integrity": "sha512-3n3nPdbUqn3nWmsy4PeSQthz2ja1ndpoXta+dwFFNhveGjMg6FXpWYe12vsTpNoXJbzx3j7GZXdtoVIdvh3JbA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000715",
-        "electron-to-chromium": "1.3.18"
+        "caniuse-lite": "1.0.30000775",
+        "electron-to-chromium": "1.3.27"
       }
     },
     "buf-compare": {
@@ -1406,7 +1155,7 @@
       "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.0",
+        "core-js": "2.5.1",
         "deep-equal": "1.0.1",
         "espurify": "1.7.0",
         "estraverse": "4.2.0"
@@ -1435,9 +1184,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000715",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000715.tgz",
-      "integrity": "sha1-wyf15tkH687GLN5ZjDvw3Xk/uaA=",
+      "version": "1.0.30000775",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000775.tgz",
+      "integrity": "sha1-dNJ/7dxH88hM+8sTDDCSo168LeI=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -1467,6 +1216,12 @@
         }
       }
     },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
     "chokidar": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
@@ -1475,7 +1230,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.1.2",
+        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -1485,9 +1240,9 @@
       }
     },
     "ci-info": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz",
-      "integrity": "sha1-3FKF8rTiUYIWg2gcOBwziPRuxTQ=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
       "dev": true
     },
     "clean-stack": {
@@ -1518,9 +1273,9 @@
       }
     },
     "cli-spinners": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.0.0.tgz",
-      "integrity": "sha1-75h+09SDkaw9q5GAtAanQhgNbmo=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.1.0.tgz",
+      "integrity": "sha1-8YR7FohE2RemceudFH499JfJDQY=",
       "dev": true
     },
     "cli-truncate": {
@@ -1534,9 +1289,9 @@
       }
     },
     "cli-width": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "co-with-promise": {
@@ -1564,9 +1319,9 @@
       "dev": true
     },
     "color-convert": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -1579,9 +1334,9 @@
       "dev": true
     },
     "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
       "dev": true
     },
     "common-path-prefix": {
@@ -1610,16 +1365,16 @@
       "requires": {
         "dot-prop": "4.2.0",
         "graceful-fs": "4.1.11",
-        "make-dir": "1.0.0",
+        "make-dir": "1.1.0",
         "unique-string": "1.0.0",
-        "write-file-atomic": "2.1.0",
+        "write-file-atomic": "2.3.0",
         "xdg-basedir": "3.0.0"
       }
     },
     "convert-source-map": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
       "dev": true
     },
     "convert-to-spaces": {
@@ -1639,9 +1394,9 @@
       }
     },
     "core-js": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
-      "integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY=",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
       "dev": true
     },
     "core-util-is": {
@@ -1690,13 +1445,13 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.30"
+        "es5-ext": "0.10.37"
       }
     },
     "date-fns": {
-      "version": "1.28.5",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.28.5.tgz",
-      "integrity": "sha1-JXz8RdMi30XvVlhmWWfuhBzXP68=",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
+      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
       "dev": true
     },
     "date-time": {
@@ -1711,9 +1466,9 @@
       "integrity": "sha1-AaqcQB7dknUFFEcLgmY5DGbGcxg="
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
       }
@@ -1748,7 +1503,7 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.1"
+        "rimraf": "2.6.2"
       },
       "dependencies": {
         "globby": {
@@ -1792,9 +1547,9 @@
       }
     },
     "diff": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.0.tgz",
-      "integrity": "sha512-w0XZubFWn0Adlsapj9EAWX0FqWdO4tz8kc3RiYdWLh4k/V8PTb6i0SMgXt0vRM3zyKnT8tKO7mUlieRQHIjMNg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
+      "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
       "dev": true
     },
     "diff-match-patch": {
@@ -1819,9 +1574,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.18",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.18.tgz",
-      "integrity": "sha1-PcyZ2j5rZl9qu8ccKK1Ros1zGpw=",
+      "version": "1.3.27",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz",
+      "integrity": "sha1-eOy4o5kGYYe7N07t412ccFZagD0=",
       "dev": true
     },
     "elegant-spinner": {
@@ -1837,7 +1592,7 @@
       "dev": true,
       "requires": {
         "call-signature": "0.0.2",
-        "core-js": "2.5.0"
+        "core-js": "2.5.1"
       }
     },
     "equal-length": {
@@ -1856,12 +1611,12 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.30",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.30.tgz",
-      "integrity": "sha1-cUGhaDZpfbq/qq7uQUlc4p9SyTk=",
+      "version": "0.10.37",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.37.tgz",
+      "integrity": "sha1-DudB0Ui4AGm6J9AgOTdWryV978M=",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.1",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
     },
@@ -1872,13 +1627,13 @@
       "dev": true
     },
     "es6-iterator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30",
+        "es5-ext": "0.10.37",
         "es6-symbol": "3.1.1"
       }
     },
@@ -1889,8 +1644,8 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30",
-        "es6-iterator": "2.0.1",
+        "es5-ext": "0.10.37",
+        "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -1903,8 +1658,8 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30",
-        "es6-iterator": "2.0.1",
+        "es5-ext": "0.10.37",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
       }
@@ -1916,7 +1671,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30"
+        "es5-ext": "0.10.37"
       }
     },
     "escape-string-regexp": {
@@ -1933,7 +1688,7 @@
       "requires": {
         "is-url": "1.2.2",
         "path-is-absolute": "1.0.1",
-        "source-map": "0.5.6",
+        "source-map": "0.5.7",
         "xtend": "4.0.1"
       }
     },
@@ -1949,7 +1704,7 @@
       "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.0"
+        "core-js": "2.5.1"
       }
     },
     "estraverse": {
@@ -1971,13 +1726,13 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30"
+        "es5-ext": "0.10.37"
       }
     },
     "exec-sh": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz",
-      "integrity": "sha1-FPdd4/INKG75MwmbLOUKkDWc7xA=",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
+      "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
       "dev": true,
       "requires": {
         "merge": "1.2.0"
@@ -2023,14 +1778,14 @@
       }
     },
     "external-editor": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.4.tgz",
-      "integrity": "sha1-HtkZnanL/i7y96MbL96LDRI2iXI=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
       "dev": true,
       "requires": {
-        "iconv-lite": "0.4.18",
-        "jschardet": "1.5.1",
-        "tmp": "0.0.31"
+        "chardet": "0.4.2",
+        "iconv-lite": "0.4.19",
+        "tmp": "0.0.33"
       }
     },
     "extglob": {
@@ -2112,9 +1867,9 @@
       }
     },
     "fs-readdir-recursive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz",
-      "integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
       "dev": true
     },
     "fs.realpath": {
@@ -2124,14 +1879,14 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.6.2",
-        "node-pre-gyp": "0.6.36"
+        "nan": "2.8.0",
+        "node-pre-gyp": "0.6.39"
       },
       "dependencies": {
         "abbrev": {
@@ -2289,7 +2044,6 @@
           "version": "2.0.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "boom": "2.10.1"
           }
@@ -2333,6 +2087,12 @@
         },
         "delegates": {
           "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2478,7 +2238,6 @@
           "version": "3.1.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "boom": "2.10.1",
             "cryptiles": "2.0.5",
@@ -2650,11 +2409,13 @@
           "optional": true
         },
         "node-pre-gyp": {
-          "version": "0.6.36",
+          "version": "0.6.39",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
             "mkdirp": "0.5.1",
             "nopt": "4.0.1",
             "npmlog": "4.1.0",
@@ -2862,7 +2623,6 @@
           "version": "1.0.9",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "hoek": "2.16.3"
           }
@@ -3023,9 +2783,9 @@
       }
     },
     "get-port": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.1.0.tgz",
-      "integrity": "sha1-7wGxioTKZIaXD/meVERhQac//T4=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
+      "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
       "dev": true
     },
     "get-stdin": {
@@ -3071,6 +2831,15 @@
       "dev": true,
       "requires": {
         "is-glob": "2.0.1"
+      }
+    },
+    "global-dirs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "dev": true,
+      "requires": {
+        "ini": "1.3.5"
       }
     },
     "globals": {
@@ -3211,9 +2980,9 @@
       }
     },
     "iconv-lite": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz",
-      "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
       "dev": true
     },
     "ignore-by-default": {
@@ -3256,22 +3025,22 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "inquirer": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.1.tgz",
-      "integrity": "sha512-QgW3eiPN8gpj/K5vVpHADJJgrrF0ho/dZGylikGX7iqAdRgC9FVKYKWFLx6hZDBFcOLEoSqINYrVPeFAeG/PdA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "2.0.0",
-        "chalk": "2.1.0",
+        "ansi-escapes": "3.0.0",
+        "chalk": "2.3.0",
         "cli-cursor": "2.1.0",
-        "cli-width": "2.1.0",
-        "external-editor": "2.0.4",
+        "cli-width": "2.2.0",
+        "external-editor": "2.1.0",
         "figures": "2.0.0",
         "lodash": "4.17.4",
         "mute-stream": "0.0.7",
@@ -3295,18 +3064,18 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.2.1"
+            "supports-color": "4.5.0"
           }
         },
         "strip-ansi": {
@@ -3319,9 +3088,9 @@
           }
         },
         "supports-color": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -3339,9 +3108,9 @@
       }
     },
     "irregular-plurals": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.3.0.tgz",
-      "integrity": "sha512-njf5A+Mxb3kojuHd1DzISjjIl+XhyzovXEOyPPSzdQozq/Lf2tN27mOrAAsxEPZxpn6I4MGzs1oo9TxXxPFpaA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
+      "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
       "dev": true
     },
     "is-arrayish": {
@@ -3356,13 +3125,13 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.10.0"
+        "binary-extensions": "1.11.0"
       }
     },
     "is-buffer": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-builtin-module": {
@@ -3380,7 +3149,7 @@
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
       "dev": true,
       "requires": {
-        "ci-info": "1.0.0"
+        "ci-info": "1.1.2"
       }
     },
     "is-dotfile": {
@@ -3446,6 +3215,16 @@
         "is-extglob": "1.0.0"
       }
     },
+    "is-installed-globally": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+      "dev": true,
+      "requires": {
+        "global-dirs": "0.1.1",
+        "is-path-inside": "1.0.1"
+      }
+    },
     "is-npm": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
@@ -3488,13 +3267,13 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "1.0.1"
       }
     },
     "is-path-inside": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
         "path-is-inside": "1.0.2"
@@ -3595,7 +3374,7 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "diff": "3.3.0",
+        "diff": "3.4.0",
         "jest-matcher-utils": "19.0.0",
         "pretty-format": "19.0.0"
       }
@@ -3682,20 +3461,14 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
-      "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
         "esprima": "4.0.0"
       }
-    },
-    "jschardet": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
-      "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A==",
-      "dev": true
     },
     "jsesc": {
       "version": "0.5.0",
@@ -3715,7 +3488,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "last-line-stream": {
@@ -3756,7 +3529,7 @@
         "is-stream": "1.1.0",
         "listr-silent-renderer": "1.1.1",
         "listr-update-renderer": "0.2.0",
-        "listr-verbose-renderer": "0.4.0",
+        "listr-verbose-renderer": "0.4.1",
         "log-symbols": "1.0.2",
         "log-update": "1.0.2",
         "ora": "0.2.3",
@@ -3825,6 +3598,34 @@
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
           }
+        }
+      }
+    },
+    "listr-input": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/listr-input/-/listr-input-0.1.2.tgz",
+      "integrity": "sha512-GQl3txLCcuKzmkYxMjZ3idiICyyjxZTfDz2k92LXU3byxY1nz249iKbfMKvSmWYUHs85TqWYZCkMJ316OKjTfA==",
+      "dev": true,
+      "requires": {
+        "inquirer": "3.3.0",
+        "rxjs": "5.5.2",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.2.tgz",
+          "integrity": "sha512-oRYoIKWBU3Ic37fLA5VJu31VqQO4bWubRntcHSJ+cwaDQBwdnZ9x4zmhJfm/nFQ2E82/I4loSioHnACamrKGgA==",
+          "dev": true,
+          "requires": {
+            "symbol-observable": "1.1.0"
+          }
+        },
+        "symbol-observable": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.1.0.tgz",
+          "integrity": "sha512-dQoid9tqQ+uotGhuTKEY11X4xhyYePVnqGSoSm3OGKh2E8LZ6RPULp1uXTctk33IeERlrRJYoVSBglsL05F5Uw==",
+          "dev": true
         }
       }
     },
@@ -3899,14 +3700,14 @@
       }
     },
     "listr-verbose-renderer": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.0.tgz",
-      "integrity": "sha1-RNwBuww0oDxXIVTU0Izemx3FYg8=",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+      "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "cli-cursor": "1.0.2",
-        "date-fns": "1.28.5",
+        "date-fns": "1.29.0",
         "figures": "1.7.0"
       },
       "dependencies": {
@@ -4110,12 +3911,20 @@
       }
     },
     "make-dir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.0.0.tgz",
-      "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
+      "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
       "dev": true,
       "requires": {
-        "pify": "2.3.0"
+        "pify": "3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
       }
     },
     "map-obj": {
@@ -4286,7 +4095,7 @@
         "normalize-path": "2.1.1",
         "object.omit": "2.0.1",
         "parse-glob": "3.0.4",
-        "regex-cache": "0.4.3"
+        "regex-cache": "0.4.4"
       }
     },
     "mimic-fn": {
@@ -4319,6 +4128,19 @@
         "minimist": "0.0.8"
       }
     },
+    "moment": {
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.3.tgz",
+      "integrity": "sha1-vbmdJw1tf9p4zA+6zoVeJ/59pp8="
+    },
+    "moment-timezone": {
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.14.tgz",
+      "integrity": "sha1-TrOP+VOLgBCLpGekWPPtQmjM/LE=",
+      "requires": {
+        "moment": "2.19.3"
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -4343,9 +4165,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
-      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U=",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
       "dev": true,
       "optional": true
     },
@@ -4373,13 +4195,13 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.0.2"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "np": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/np/-/np-2.16.0.tgz",
-      "integrity": "sha512-eLkiVDfkzXl4qDp/ozLhz/9ySK0Kd02So1FqspZqS3Ix/LtuuZjhhHGS6+3a32tn4+mSxXxSir1/anr5oWgU4Q==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/np/-/np-2.17.0.tgz",
+      "integrity": "sha512-60q9qIyeAsBgMshQ/93vglkIdrlSanG3EysQj3Q3n0X7BWfkz2LMkoaBo9eIuSQHDx/vBlG8t6ZXTlg8Wz2ViA==",
       "dev": true,
       "requires": {
         "any-observable": "0.2.0",
@@ -4387,8 +4209,9 @@
         "del": "2.2.2",
         "execa": "0.6.3",
         "has-yarn": "1.0.0",
-        "inquirer": "3.2.1",
+        "inquirer": "3.3.0",
         "listr": "0.11.0",
+        "listr-input": "0.1.2",
         "log-symbols": "1.0.2",
         "meow": "3.7.0",
         "read-pkg-up": "2.0.0",
@@ -4396,7 +4219,7 @@
         "semver": "5.4.1",
         "split": "1.0.1",
         "stream-to-observable": "0.2.0",
-        "update-notifier": "2.2.0"
+        "update-notifier": "2.3.0"
       },
       "dependencies": {
         "execa": {
@@ -4454,13 +4277,13 @@
       "dev": true,
       "requires": {
         "is-observable": "0.2.0",
-        "symbol-observable": "1.0.4"
+        "symbol-observable": "1.1.0"
       },
       "dependencies": {
         "symbol-observable": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
-          "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.1.0.tgz",
+          "integrity": "sha512-dQoid9tqQ+uotGhuTKEY11X4xhyYePVnqGSoSm3OGKh2E8LZ6RPULp1uXTctk33IeERlrRJYoVSBglsL05F5Uw==",
           "dev": true
         }
       }
@@ -4753,7 +4576,7 @@
       "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
       "dev": true,
       "requires": {
-        "irregular-plurals": "1.3.0"
+        "irregular-plurals": "1.4.0"
       }
     },
     "prepend-http": {
@@ -4783,7 +4606,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "1.9.1"
           }
         }
       }
@@ -4808,9 +4631,9 @@
       }
     },
     "private": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-      "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE=",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
       "dev": true
     },
     "process-nextick-args": {
@@ -4826,12 +4649,13 @@
       "dev": true
     },
     "quibble": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/quibble/-/quibble-0.5.1.tgz",
-      "integrity": "sha1-t/0fwKnB7qASrJ1xvLbajZpdyek=",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/quibble/-/quibble-0.5.3.tgz",
+      "integrity": "sha512-HL+gtKkDOo1HlxDpWaBd2xbkVg3sQeP0mS39kdF1CzkdNcY0bOVxzjGOs35oEjbDTbL8DtgP24UGgrd0cr9x8w==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "4.17.4",
+        "resolve": "1.5.0"
       }
     },
     "randomatic": {
@@ -4859,7 +4683,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -4870,19 +4694,19 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
     },
     "rc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
+      "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
       "dev": true,
       "requires": {
         "deep-extend": "0.4.2",
-        "ini": "1.3.4",
+        "ini": "1.3.5",
         "minimist": "1.2.0",
         "strip-json-comments": "2.0.1"
       },
@@ -4993,36 +4817,35 @@
       }
     },
     "regenerate": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-      "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA=",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
       "dev": true
     },
     "regenerator-runtime": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
       "dev": true
     },
     "regenerator-transform": {
-      "version": "0.9.11",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
-      "integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.25.0",
-        "babel-types": "6.25.0",
-        "private": "0.1.7"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "private": "0.1.8"
       }
     },
     "regex-cache": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3",
-        "is-primitive": "2.0.0"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "regexpu-core": {
@@ -5031,7 +4854,7 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "1.3.2",
+        "regenerate": "1.3.3",
         "regjsgen": "0.2.0",
         "regjsparser": "0.1.5"
       }
@@ -5042,7 +4865,7 @@
       "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
       "dev": true,
       "requires": {
-        "rc": "1.2.1",
+        "rc": "1.2.2",
         "safe-buffer": "5.1.1"
       }
     },
@@ -5052,7 +4875,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.1"
+        "rc": "1.2.2"
       }
     },
     "regjsgen": {
@@ -5080,9 +4903,9 @@
       }
     },
     "remove-trailing-separator": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
-      "integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
     },
     "repeat-element": {
@@ -5113,9 +4936,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "dev": true,
       "requires": {
         "path-parse": "1.0.5"
@@ -5155,9 +4978,9 @@
       }
     },
     "rimraf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
         "glob": "7.1.2"
@@ -5193,13 +5016,13 @@
       "integrity": "sha512-fSNi+y+P9ss+EZuV0GcIIqPUK07DEaMRUtLJvdcvMyFjc9dizuDjere+A4V7JrLGnm9iCc+nagV/4QdMTkqC4A==",
       "dev": true,
       "requires": {
-        "symbol-observable": "1.0.4"
+        "symbol-observable": "1.1.0"
       },
       "dependencies": {
         "symbol-observable": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
-          "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.1.0.tgz",
+          "integrity": "sha512-dQoid9tqQ+uotGhuTKEY11X4xhyYePVnqGSoSm3OGKh2E8LZ6RPULp1uXTctk33IeERlrRJYoVSBglsL05F5Uw==",
           "dev": true
         }
       }
@@ -5207,8 +5030,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "semver": {
       "version": "5.4.1",
@@ -5283,18 +5105,18 @@
       }
     },
     "source-map": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
     "source-map-support": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
-      "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "source-map": "0.5.6"
+        "source-map": "0.5.7"
       }
     },
     "spdx-correct": {
@@ -5475,8 +5297,8 @@
       "requires": {
         "es6-map": "0.1.5",
         "lodash": "4.17.4",
-        "quibble": "0.5.1",
-        "resolve": "1.4.0",
+        "quibble": "0.5.3",
+        "resolve": "1.5.0",
         "stringify-object-es5": "2.5.0"
       }
     },
@@ -5593,9 +5415,9 @@
       "dev": true
     },
     "tmp": {
-      "version": "0.0.31",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
-      "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
         "os-tmpdir": "1.0.2"
@@ -5652,19 +5474,51 @@
       "dev": true
     },
     "update-notifier": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.2.0.tgz",
-      "integrity": "sha1-G1g3z5DAc22IYncytmHBOPht5y8=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
+      "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
       "dev": true,
       "requires": {
-        "boxen": "1.2.1",
-        "chalk": "1.1.3",
+        "boxen": "1.2.2",
+        "chalk": "2.3.0",
         "configstore": "3.1.1",
         "import-lazy": "2.1.0",
+        "is-installed-globally": "0.1.0",
         "is-npm": "1.0.0",
         "latest-version": "3.1.0",
         "semver-diff": "2.1.0",
         "xdg-basedir": "3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
       }
     },
     "url-parse-lax": {
@@ -5718,7 +5572,7 @@
       "integrity": "sha1-NApxe952Vyb6CqB9ch4BR6VR3ww=",
       "dev": true,
       "requires": {
-        "exec-sh": "0.2.0",
+        "exec-sh": "0.2.1",
         "minimist": "1.2.0"
       },
       "dependencies": {
@@ -5777,28 +5631,28 @@
       "dev": true
     },
     "write-file-atomic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.1.0.tgz",
-      "integrity": "sha512-0TZ20a+xcIl4u0+Mj5xDH2yOWdmQiXlKf9Hm+TgDXjTMsEYb+gDrmb8e8UNAzMCitX8NBqG4Z/FUQIyzv/R1JQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "imurmurhash": "0.1.4",
-        "slide": "1.1.6"
+        "signal-exit": "3.0.2"
       }
     },
     "write-json-file": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.2.0.tgz",
-      "integrity": "sha1-UYYlBruzthnu+reFnx/WxtBTCHY=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
+      "integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
       "dev": true,
       "requires": {
         "detect-indent": "5.0.0",
         "graceful-fs": "4.1.11",
-        "make-dir": "1.0.0",
-        "pify": "2.3.0",
-        "sort-keys": "1.1.2",
-        "write-file-atomic": "2.1.0"
+        "make-dir": "1.1.0",
+        "pify": "3.0.0",
+        "sort-keys": "2.0.0",
+        "write-file-atomic": "2.3.0"
       },
       "dependencies": {
         "detect-indent": {
@@ -5807,14 +5661,11 @@
           "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
           "dev": true
         },
-        "sort-keys": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
-          "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-          "dev": true,
-          "requires": {
-            "is-plain-obj": "1.1.0"
-          }
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
         }
       }
     },
@@ -5825,7 +5676,7 @@
       "dev": true,
       "requires": {
         "sort-keys": "2.0.0",
-        "write-json-file": "2.2.0"
+        "write-json-file": "2.3.0"
       }
     },
     "xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "death": "^1.1.0",
     "debug": "^2.6.8",
     "lodash": "^4.17.4",
+    "moment": "^2.19.3",
+    "moment-timezone": "^0.5.14",
     "uuid": "^3.0.1"
   },
   "devDependencies": {

--- a/src/lib/plugins/dateparser.plugin.js
+++ b/src/lib/plugins/dateparser.plugin.js
@@ -1,0 +1,58 @@
+/* eslint no-cond-assign: 0, no-empty: 0 */
+const _ = require('lodash');
+const moment = require('moment-timezone');
+
+/*
+   Parses JSON dates to be turned into Javascript Dates
+   Taken from express body-parser (this acts the same way but for bunnyhop)
+ */
+const regexIso8601 = /^(\d{4}|\+\d{6})(?:-(\d{2})(?:-(\d{2})(?:T(\d{2}):(\d{2}):(\d{2})\.(\d{1,})(Z|([-+])(\d{2}):(\d{2}))?)?)?)?$/;
+
+function parseDate(key, value) {
+  try {
+    let match;
+    if (typeof value === 'string' && (match = value.match(regexIso8601))) {
+      const m = moment.utc(value);
+      if (m) return m.toDate();
+    }
+  } catch (err) {}
+  return value;
+}
+
+function mapValuesDeep(v, callback, k) {
+  return _.isObjectLike(v)
+    ? _.mapValues(v, (val, key) => mapValuesDeep(val, callback, key))
+    : callback(v, k);
+}
+
+/*
+    Parses dates in the bunnyhop payload from JSON strings into date objects.
+ */
+function DateParserPlugin(pluginAPI) {
+  const log = pluginAPI.getPluginLogger();
+  log.info('Using DateParser Plugin');
+  return {
+    send: next =>
+      (routingKey, message, options) => next(routingKey, message, options),
+
+    listen: next =>
+      async (routingKey, listenFn, options) => {
+        function parseDates (msg) {
+          const payload = _.get(msg, 'content.data');
+          if (payload) {
+            msg.content.data = mapValuesDeep(payload, (v, k) => parseDate(k, v));
+          }
+          return listenFn(msg);
+        }
+        return next(routingKey, parseDates, options);
+      },
+
+    publish: next =>
+      (routingKey, message, options) => next(routingKey, message, options),
+
+    subscribe: next =>
+      (routingKey, subscribeFn, options) => next(routingKey, subscribeFn, options)
+  };
+}
+
+module.exports = DateParserPlugin;


### PR DESCRIPTION
This is old middleware I wrote for burgertime months ago but am copying the file here so that other projects can use it. 

It is actually ripped off from express body-parser.  No credit to me.

When inbound JSON has dates, the JSON parser does not turn them into date objects because JSON isn't typed... it just assumes its a string.   Depending on what you want to do with these dates it becomes a pain to constantly be making `new Date` every time.

This body-parer plugin matches ISO format UTC date strings using a regex (I didn't write it) and turns them into Date objects. 

This is very handy when working with a lot of dates...