### PR TITLE
onHandlerComplete and onHandlerError Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ Top-level options exposed by BunnyHop
 | url | AMQP URL to connect to  | `'amqp://localhost'` |
 | serialization | manager to use for serializing and deserializing messages | `require('./lib/serialization/json')` |
 | connectionManager | manager to use for handling connection to AMQP server | `require('./lib/connectionManager')` |
+| onHandlerCompleted| function with signature is onHandlerCompleted({*} Result, {Array<*>} OriginalHandlerArguments) called when listen/subscribe handler completes.| undefined |
+| onHandlerError| function with signature onHandlerError(Error) called when listen/subscribe throws an error/returns rejected promise | undefined |
+
+**Note**
+
+The `onHandlerCompleted` does not affect return values of the handler. It is purely a side effect.
+
+The `onHandlerError` hooks does not affect error bubbling. It is purely a side effect. 
+
+-----------------
 
 Top-level options exposed by the [Default Engine](#plugins-and-engines):
 

--- a/README.md
+++ b/README.md
@@ -112,14 +112,13 @@ Top-level options exposed by BunnyHop
 | url | AMQP URL to connect to  | `'amqp://localhost'` |
 | serialization | manager to use for serializing and deserializing messages | `require('./lib/serialization/json')` |
 | connectionManager | manager to use for handling connection to AMQP server | `require('./lib/connectionManager')` |
-| onHandlerSuccess| function with signature is onHandlerSuccess({*} Result, {Array<*>} OriginalHandlerArguments) called when listen/subscribe handler completes.| undefined |
+| onHandlerSuccess| function with signature is onHandlerSuccess({*} Result, ...{*} OriginalHandlerArguments) called when listen/subscribe handler completes.| undefined |
 | onHandlerError| function with signature onHandlerError(Error) called when listen/subscribe throws an error/returns rejected promise | undefined |
 
 **Note**
 
 The `onHandlerSuccess` does not affect return values of the handler. It is purely a side effect.
-
-The `onHandlerError` hooks does not affect error bubbling. It is purely a side effect. 
+The `onHandlerError` hooks CONSUMES the error. Errors will not propagate unless you throw them again 
 
 -----------------
 

--- a/README.md
+++ b/README.md
@@ -112,12 +112,12 @@ Top-level options exposed by BunnyHop
 | url | AMQP URL to connect to  | `'amqp://localhost'` |
 | serialization | manager to use for serializing and deserializing messages | `require('./lib/serialization/json')` |
 | connectionManager | manager to use for handling connection to AMQP server | `require('./lib/connectionManager')` |
-| onHandlerCompleted| function with signature is onHandlerCompleted({*} Result, {Array<*>} OriginalHandlerArguments) called when listen/subscribe handler completes.| undefined |
+| onHandlerSuccess| function with signature is onHandlerSuccess({*} Result, {Array<*>} OriginalHandlerArguments) called when listen/subscribe handler completes.| undefined |
 | onHandlerError| function with signature onHandlerError(Error) called when listen/subscribe throws an error/returns rejected promise | undefined |
 
 **Note**
 
-The `onHandlerCompleted` does not affect return values of the handler. It is purely a side effect.
+The `onHandlerSuccess` does not affect return values of the handler. It is purely a side effect.
 
 The `onHandlerError` hooks does not affect error bubbling. It is purely a side effect. 
 

--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,7 @@ function BunnyHop (serviceName, options = {}) {
 
     listen: async (routingKey, listenFn, listenOptions) => {
       const pm = await pluginManagerPromise;
-      const handler = wrapCompletedHandlers(listenFn, options.onHanderError, options.onHandlerSuccess);
+      const handler = wrapCompletedHandlers(listenFn, options.onHandlerError, options.onHandlerCompleted);
       return pm.listen(routingKey, handler, listenOptions);
     },
 
@@ -84,7 +84,7 @@ function BunnyHop (serviceName, options = {}) {
 
     async subscribe (routingKey, subscribeFn, subscribeOptions) {
       const pm = await pluginManagerPromise;
-      const handler = wrapCompletedHandlers(subscribeFn, options.onHanderError, options.onHandlerSuccess);
+      const handler = wrapCompletedHandlers(subscribeFn, options.onHandlerError, options.onHandlerCompleted);
       return pm.subscribe(routingKey, handler, subscribeOptions);
     }
   };

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ function BunnyHop (serviceName, options = {}) {
     connectionManager: DefaultConnectionManager,
     /*
     onHandlerError: fn,
-    onHandlerCompleted: fn
+    onHandlerSuccess: fn
      */
   });
 
@@ -72,7 +72,7 @@ function BunnyHop (serviceName, options = {}) {
 
     listen: async (routingKey, listenFn, listenOptions) => {
       const pm = await pluginManagerPromise;
-      const handler = wrapCompletedHandlers(listenFn, options.onHandlerError, options.onHandlerCompleted);
+      const handler = wrapCompletedHandlers(listenFn, options.onHandlerError, options.onHandlerSuccess);
       return pm.listen(routingKey, handler, listenOptions);
     },
 
@@ -84,7 +84,7 @@ function BunnyHop (serviceName, options = {}) {
 
     async subscribe (routingKey, subscribeFn, subscribeOptions) {
       const pm = await pluginManagerPromise;
-      const handler = wrapCompletedHandlers(subscribeFn, options.onHandlerError, options.onHandlerCompleted);
+      const handler = wrapCompletedHandlers(subscribeFn, options.onHandlerError, options.onHandlerSuccess);
       return pm.subscribe(routingKey, handler, subscribeOptions);
     }
   };

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1,7 +1,7 @@
 /**
  * Created by balmasi on 2017-05-31.
  */
-const { snakeCase, wrap, isFunction } = require('lodash');
+const { snakeCase, isFunction } = require('lodash');
 
 class TimeoutError extends Error {
   constructor(...args) {
@@ -32,7 +32,6 @@ function toKeymap (array = []) {
  * return or resolve within timeoutMs milliseconds
  *
  * @param {number} timeoutMs - milliseconds to wait before rejecting calls
- * @param {function} fn - a function to add timeout behaviour to
  * @returns {function(...[*]): Promise.<*>}
  */
 function getRejectedPromiseIfTimedOut (timeoutMs) {

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -51,7 +51,7 @@ const wrapCompletedHandlers = (orignalFn, onError, onSuccess) => (...args) => {
   let returnVal;
   const callOnSuccess = (returnVal) => {
     if (isFunction(onSuccess)) {
-      onSuccess(returnVal, args);
+      onSuccess(returnVal, ...args);
     }
   };
   const callOnError = (error) => {

--- a/src/lib/util.test.js
+++ b/src/lib/util.test.js
@@ -1,9 +1,78 @@
 const test = require('ava');
+const td = require('testdouble');
 
-const { getRejectedPromiseIfTimedOut, TimeoutError } = require('./util');
+const { getRejectedPromiseIfTimedOut, TimeoutError, wrapCompletedHandlers } = require('./util');
+
+test.beforeEach(() => td.reset());
 
 test('#getRejectedPromiseIfTimedOut - Should reject a promise after given milliseconds', async t => {
   const before = Date.now();
   await t.throws(getRejectedPromiseIfTimedOut(500), TimeoutError);
   t.true(Date.now() - before - 500 < 20);
+});
+
+const w = wrapCompletedHandlers;
+test('#wrapCompletedHandlers - synchronous functions', t => {
+  const onSuccess = td.function('onSuccess');
+  const onError = td.function('onError');
+  const syncFunction = (a, b) => a + b;
+  const syncFunctionThrows = () => {
+    throw new Error('sync error');
+  };
+
+  t.is(w(syncFunction)(1,2), 3, 'should still return original value');
+  t.throws(w(syncFunctionThrows), Error, 'sync error', 'should throw synchronous error');
+
+  w(syncFunction, onError)(1,2);
+  td.verify(onSuccess(), { ignoreExtraArgs: true, times: 0 });
+  td.verify(onError(), { ignoreExtraArgs: true, times: 0 });
+
+  w(syncFunction, null, onSuccess)(1,2);
+  td.verify(onSuccess(3, [1, 2]));
+
+  t.throws(w(syncFunctionThrows, onError));
+  td.verify(onError(new Error('sync error')));
+
+  t.is(w(syncFunction, onError, onSuccess)(3,4), 7);
+  td.verify(onSuccess(7, [3, 4]));
+
+  t.throws(
+    w(syncFunctionThrows, onError, onSuccess),
+    Error,
+    'sync error',
+    'should throw synchronous error'
+  );
+  td.verify(onError(new Error('sync error')));
+});
+
+test('#wrapCompletedHandlers - async functions', async t => {
+  const asyncFunction = (a, b) => Promise.resolve(a + b);
+  const asyncFunctionRejects = (a, b) => Promise.reject(
+    new Error('async rejection')
+  );
+  const onSuccess = td.function('onSuccess');
+  const onError = td.function('onError');
+
+  t.is(await w(asyncFunction)(1,2), 3, 'should still return original value');
+  await t.throws(w(asyncFunctionRejects)(), Error, 'async rejection', 'should throw async error');
+  await w(asyncFunction, onError)(1,2);
+  td.verify(onSuccess(), { ignoreExtraArgs: true, times: 0 });
+  td.verify(onError(), { ignoreExtraArgs: true, times: 0 });
+
+  await w(asyncFunction, null, onSuccess)(1,2);
+  td.verify(onSuccess(3, [1, 2]));
+
+  await t.throws(w(asyncFunctionRejects, onError)());
+  td.verify(onError(new Error('async rejection')));
+
+  t.is(await w(asyncFunction, onError, onSuccess)(3,4), 7);
+  td.verify(onSuccess(7, [3, 4]));
+
+  await t.throws(
+    w(asyncFunctionRejects, onError, onSuccess)(6, 6),
+    Error,
+    'async rejection',
+    'should throw async error'
+  );
+  td.verify(onError(new Error('async rejection')));
 });

--- a/src/lib/util.test.js
+++ b/src/lib/util.test.js
@@ -28,13 +28,13 @@ test('#wrapCompletedHandlers - synchronous functions', t => {
   td.verify(onError(), { ignoreExtraArgs: true, times: 0 });
 
   w(syncFunction, null, onSuccess)(1,2);
-  td.verify(onSuccess(3, [1, 2]));
+  td.verify(onSuccess(3, 1, 2));
 
   t.throws(w(syncFunctionThrows, onError));
   td.verify(onError(new Error('sync error')));
 
   t.is(w(syncFunction, onError, onSuccess)(3,4), 7);
-  td.verify(onSuccess(7, [3, 4]));
+  td.verify(onSuccess(7, 3, 4));
 
   t.throws(
     w(syncFunctionThrows, onError, onSuccess),
@@ -60,13 +60,13 @@ test('#wrapCompletedHandlers - async functions', async t => {
   td.verify(onError(), { ignoreExtraArgs: true, times: 0 });
 
   await w(asyncFunction, null, onSuccess)(1,2);
-  td.verify(onSuccess(3, [1, 2]));
+  td.verify(onSuccess(3, 1, 2));
 
   await t.throws(w(asyncFunctionRejects, onError)());
   td.verify(onError(new Error('async rejection')));
 
   t.is(await w(asyncFunction, onError, onSuccess)(3,4), 7);
-  td.verify(onSuccess(7, [3, 4]));
+  td.verify(onSuccess(7, 3, 4));
 
   await t.throws(
     w(asyncFunctionRejects, onError, onSuccess)(6, 6),


### PR DESCRIPTION
The thought here is to allow a central place for failures and successes for things like logging and other side effects.

This is something that pretty much any engine needs to support so it's been brought into code.

This way we don't have to use the bunnyhop-handlers package to achieve this.